### PR TITLE
fix validation TypeError

### DIFF
--- a/Classes/Powermail/Validator/OptinValidator.php
+++ b/Classes/Powermail/Validator/OptinValidator.php
@@ -27,7 +27,7 @@ class OptinValidator
      * @param string $validationConfiguration
      * @return bool
      */
-    public function validate120($value, $validationConfiguration): bool
+    public function validateOptin($value, $validationConfiguration): bool
     {
         $value = trim($value);
 

--- a/Classes/Powermail/Validator/OptoutValidator.php
+++ b/Classes/Powermail/Validator/OptoutValidator.php
@@ -25,7 +25,7 @@ class OptoutValidator
      * @param string $validationConfiguration
      * @return bool
      */
-    public function validate121($value, $validationConfiguration): bool
+    public function validateOptout($value, $validationConfiguration): bool
     {
         $value = trim($value);
 

--- a/Configuration/TypoScript/Powermail/setup.txt
+++ b/Configuration/TypoScript/Powermail/setup.txt
@@ -8,8 +8,8 @@ plugin.tx_powermail {
             native = 1
             server = 1
             customValidation {
-                120 = WapplerSystems\Cleverreach\Powermail\Validator\OptinValidator
-                121 = WapplerSystems\Cleverreach\Powermail\Validator\OptoutValidator
+                optin = WapplerSystems\Cleverreach\Powermail\Validator\OptinValidator
+                optout = WapplerSystems\Cleverreach\Powermail\Validator\OptoutValidator
             }
         }
 
@@ -25,9 +25,9 @@ plugin.tx_powermail {
         }
 
     }
-    _LOCAL_LANG.default.validationerror_validation.120 = No correct email address or already in list
-    _LOCAL_LANG.de.validationerror_validation.120 = Keine korrekte Email-Adresse oder sie befindet sich schon in der Liste
+    _LOCAL_LANG.default.validationerror_validation.optin = No correct email address or already in list
+    _LOCAL_LANG.de.validationerror_validation.optin = Keine korrekte Email-Adresse oder sie befindet sich schon in der Liste
 
-    _LOCAL_LANG.default.validationerror_validation.121 = This email address is not in our list
-    _LOCAL_LANG.de.validationerror_validation.121 = Diese Email-Adresse befindet sich nicht in unserer Liste
+    _LOCAL_LANG.default.validationerror_validation.optout = This email address is not in our list
+    _LOCAL_LANG.de.validationerror_validation.optout = Diese Email-Adresse befindet sich nicht in unserer Liste
 }

--- a/Configuration/TypoScript/TsConfig/Page/powermail.ts
+++ b/Configuration/TypoScript/TsConfig/Page/powermail.ts
@@ -1,7 +1,7 @@
 
 
-tx_powermail.flexForm.validation.addFieldOptions.120 = CleverReach Optin Email
-tx_powermail.flexForm.validation.addFieldOptions.121 = CleverReach Optout Email
+tx_powermail.flexForm.validation.addFieldOptions.optin = CleverReach Optin Email
+tx_powermail.flexForm.validation.addFieldOptions.optout = CleverReach Optout Email
 
 
 tx_powermail.flexForm.addField.settings\.flexform\.main\.cleverreach._sheet = main


### PR DESCRIPTION
Hello,

we're using 

- powermail 5.1.0
- cleverreach 0.1.2
- TYPO3 8.7.9
- PHP 7.0.27

Following error is thrown when trying to add new fields within the powermail form:
`Core: Exception handler (WEB): Uncaught TYPO3 Exception: substr() expects parameter 1 to be string, integer given | TypeError thrown in file /var/www/typo3.lab/typo3conf/ext/powermail/Classes/Tca/AddOptionsToSelection.php in line 107. Requested URL: http://t3.domain.de/typo3/index.php?ajaxID=%2Fajax%2Frecord%2Finline%2Fcreate&ajaxToken=1022e8233d4a37c2cb1d9b2187afe1d2be661b54`

The reason for this behaviour is probably the first line in the powermail extension's php files:
`declare(strict_types=1);`

We patched the cleverreach locally in order to work around this issue (see diff).
Feel free to make changes as I can not tell whether this will work with older powermail versions.

I also opened an issue here https://github.com/einpraegsam/powermail/issues/226

Kind regards
Kevin
