### PR TITLE
fix finisher identifier

### DIFF
--- a/Configuration/Yaml/BaseSetup.yaml
+++ b/Configuration/Yaml/BaseSetup.yaml
@@ -42,7 +42,7 @@ TYPO3:
                   900:
                     selectOptions:
                       90:
-                        value: 'CleverReach'
+                        value: 'Cleverreach'
                         label: 'CleverReach'
 
                 propertyCollections:


### PR DESCRIPTION
The finisher identifier in the finisher dropdown wasn't consistent with the finisherDefinition. This made it impossible to create a form with a clever reach finisher. Furthermore, the form would get buggy since the form framework tries to load a finisher which isn't defined.