### PR TITLE
Add compatibility to "subtree split"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "http://wappler.systems",
     "license": "GPL-2.0-or-later",
     "require": {
-        "typo3/cms": ">=7.6.0, <8.7.99"
+        "typo3/cms-core": "^7.6 || ^8.7"
     },
     "replace": {
         "svewap/cleverreach": "self.version"


### PR DESCRIPTION
Since TYPO3 8, you can install TYPO3 in "subtree split" mode, without "typo3/cms". When I add your package to my project, it requires "typo3/cms" and installs it, this breaks my "subtree split" project.
To fix this, the requirement "typo3/cms" is changed to "typo3/cms-core". That's the correct way to require TYPO3 versions for "subtree split" and regular projects.
See: https://insight.helhum.io/post/155297666635/typo3-extension-dependencies-revisited