### PR TITLE
[BUGFIX] Return global attributes in toArray()

### DIFF
--- a/Classes/Domain/Model/Receiver.php
+++ b/Classes/Domain/Model/Receiver.php
@@ -87,7 +87,7 @@ class Receiver
             'deactivated' => $this->deactivated,
             'registered' => $this->registered,
             'attributes' => $this->attributes,
-            'global_attributes' => $this->attributes,
+            'global_attributes' => $this->globalAttributes,
             'source' => 'TYPO3',
         ];
     }


### PR DESCRIPTION
In the reciever toArray method the normal attributes are returned as global_attributes.