### PR TITLE
[TASK] Add support for HTTP proxies

### DIFF
--- a/Classes/Tools/Rest.php
+++ b/Classes/Tools/Rest.php
@@ -251,6 +251,16 @@ class Rest
 
         $this->debugValues->header = $header;
         curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
+
+        // Set Proxy if configured (TYPO3 9.5)
+        if ($GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']) {
+            curl_setopt($curl, CURLOPT_PROXY, $GLOBALS['TYPO3_CONF_VARS']['HTTP']['proxy']);
+        }
+
+        // Set Proxy if configured (TYPO3 7.6 and 8.7)
+        if ($GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']) {
+            curl_setopt($curl, CURLOPT_PROXY, $GLOBALS['TYPO3_CONF_VARS']['SYS']['curlProxyServer']);
+        }
     }
 
     /**


### PR DESCRIPTION
If TYPO3 is configured to use a proxy server for outgoing traffic,
the API requests to cleverreach will fail.

With this patch, the proxy server configured in TYPO3 install tool
will be used for all curl requests.

On a long run, it will be better to get rid of the custom implementation
for HTTP requests and use Guzzle (bundled in TYPO3 Core since V8)
instead.